### PR TITLE
Fix: Add Alembic dependency and correct start script for Railway deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pydantic
 python-dotenv
 passlib[bcrypt]
 cryptography
+alembic


### PR DESCRIPTION
This PR resolves the deployment failure on Railway caused by the missing Alembic command (alembic: command not found).